### PR TITLE
Added JWT for login/signup

### DIFF
--- a/flask/app/__init__.py
+++ b/flask/app/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask, g
 from flask_cors import CORS
 from flask_bcrypt import Bcrypt
+from flask_jwt_extended import JWTManager
 import mysql.connector
 import os
 from .config import Config
@@ -49,11 +50,13 @@ def create_app():
     Registers routes defined in routes.py
     """
     app = Flask(__name__)
-    CORS(app) # Make this better in production
-    bcrypt.init_app(app)
 
     app.config.from_object(Config)
     app.teardown_appcontext(disconnect_db)
+
+    CORS(app) # Make this better in production
+    bcrypt.init_app(app)
+    jwt = JWTManager(app)
 
     from .routes import routes
     from .auth import auth

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -2,4 +2,5 @@ Flask==3.0.3
 mysql-connector-python==9.1.0
 python-dotenv==1.0.1
 Flask-Cors==5.0.0
-Flask-Bcrypt
+Flask-Bcrypt==1.0.1
+Flask-JWT-Extended==4.6.0


### PR DESCRIPTION
Added JWT authentication for the /login and /signup routes. These endpoints now either return a more specific error or JSON in the form of {"jwt": <jwt_access_token>}. This token should be used for all subsequent API calls.