### PR TITLE
Added profile routes

### DIFF
--- a/project/create_db_queries/create.sql
+++ b/project/create_db_queries/create.sql
@@ -10,7 +10,7 @@ USE Climbing;
 
 -- User that Flask uses to connect to database
 -- CREATE USER 'flask'@'%' IDENTIFIED BY 'Fl@5kFl@5k!';
-GRANT SELECT, INSERT, DELETE ON Climbing.* TO 'flask'@'%';
+GRANT SELECT, INSERT, UPDATE, DELETE ON Climbing.* TO 'flask'@'%';
 FLUSH PRIVILEGES;
 
 CREATE TABLE c_user (


### PR DESCRIPTION
Profile routes are now implemented at `/profile`. Requires JWT. The methods are used,

* `GET`: Returns all profile setting for a user
* `PUT`: Updates specific profile settings. Needs one or more of the following variables in body, `username`, `pronouns`, `ability`, `date_of_birth`
* `DELETE`: Deletes the user from the database